### PR TITLE
Fix an issue when `~/.local/share/Steam/compatibilitytools.d` does not exist

### DIFF
--- a/steam/CompatTools.go
+++ b/steam/CompatTools.go
@@ -1,6 +1,7 @@
 package steam
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path"
@@ -108,7 +109,11 @@ func (s *Steam) ReadCompatTools() error {
 
 	files, err := ioutil.ReadDir(s.GetCompatibilityToolsDir())
 	if err != nil {
-		return err
+		// If this directory does not exist, that's actually fine.
+		// It can be treated as an empty folder in that scenario.
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
 	}
 
 	for _, file := range files {


### PR DESCRIPTION
On some Steam setups (such as mine), this directory does not exist. I tried to `mkdir` that directory manually and then `protonutils` worked fine.

This patch makes it so it is just treated as an empty directory if it does not exist.

(This is my first time doing anything in Go, so I'm sorry if I did something un-idiomatic.)